### PR TITLE
Added timeout to http_connection

### DIFF
--- a/lib/oauth2-client/connection.rb
+++ b/lib/oauth2-client/connection.rb
@@ -85,11 +85,13 @@ module OAuth2Client
     end
 
     def http_connection(opts={})
-      _host   = opts[:host]   || host
-      _port   = opts[:port]   || port
-      _scheme = opts[:scheme] || scheme
+      _host    = opts[:host]   || host
+      _port    = opts[:port]   || port
+      _scheme  = opts[:scheme] || scheme
+      _timeout = opts[:timeout]
 
       @http_client = Net::HTTP.new(_host, _port)
+      @http_client.read_timeout = _timeout if _timeout
 
       configure_ssl(@http_client) if _scheme == 'https'
 


### PR DESCRIPTION
Added an option opts[:timeout] that can be passed to http_connection to set the read_timeout on the http_client.
